### PR TITLE
docs: update engine example links for grouped framework folders

### DIFF
--- a/cn/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
+++ b/cn/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
@@ -236,7 +236,7 @@ import QuickAccessERFooter from "/cn/snippets/quick-access-er-footer.mdx";
         <Card
           title="Magic Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
           iconType="duotone"
         >
           在 GitHub 上查看参考实现

--- a/cn/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/cn/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ import DelegationInfo from "/cn/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Rust Counter 的测试
@@ -36,7 +36,7 @@ import DelegationInfo from "/cn/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio/tests"
     iconType="duotone"
   >
     Pinocchio Counter 的测试
@@ -56,7 +56,7 @@ import DelegationInfo from "/cn/snippets/delegation-info.mdx";
 ## 分步指南
 
 构建能够调用程序中 delegation 和 undelegation instruction 的有效交易。
-该项目的完整测试可以在 [Typescript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests) 中找到。
+该项目的完整测试可以在 [Typescript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) 中找到。
 
 <Steps>
   <Step

--- a/cn/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/cn/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ import DelegationInfo from "/cn/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Rust Counter 的测试
@@ -56,7 +56,7 @@ import DelegationInfo from "/cn/snippets/delegation-info.mdx";
 ## 分步指南
 
 构建能够调用程序中 delegation 和 undelegation instruction 的有效交易。
-该项目的完整测试可以在 [Typescript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) 中找到。
+该项目的完整测试可以在 [Typescript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests) 中找到。
 
 <Steps>
   <Step

--- a/cn/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
+++ b/cn/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
@@ -287,7 +287,7 @@ await erProgram.methods
   <Card
     title="Ephemeral Accounts Demo"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/programs/ephemeral-account-chats"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/anchor/programs/ephemeral-account-chats"
     iconType="duotone"
   >
     Full example program on GitHub

--- a/cn/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
+++ b/cn/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
@@ -52,7 +52,7 @@ import MagicRouterSDK from "/cn/snippets/magic-router-sdk.mdx";
   <Card
     title="Anchor"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     与 Anchor 程序集成
@@ -60,7 +60,7 @@ import MagicRouterSDK from "/cn/snippets/magic-router-sdk.mdx";
   <Card
     title="Native Rust"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     与 Native Rust 程序集成

--- a/cn/pages/ephemeral-rollups-ers/magic-actions/client.mdx
+++ b/cn/pages/ephemeral-rollups-ers/magic-actions/client.mdx
@@ -14,7 +14,7 @@ import KitCode from "/cn/snippets/magic-router-code/kit.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     在 GitHub 上查看参考实现

--- a/cn/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
+++ b/cn/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
@@ -13,7 +13,7 @@ import MagicActionExample from "/cn/snippets/magic-action-example.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     在 GitHub 上查看参考实现

--- a/cn/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
+++ b/cn/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
@@ -13,7 +13,7 @@ import DemoCards from "/cn/snippets/demo-cards.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     在 GitHub 上查看参考实现

--- a/cn/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
+++ b/cn/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
@@ -55,7 +55,7 @@ description: 诊断 Magic Actions 的常见问题
 <Card
   title="Magic Actions Example"
   icon="code"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
   iconType="duotone"
 >
   在 GitHub 上查看参考实现

--- a/cn/pages/get-started/how-integrate-your-program/anchor.mdx
+++ b/cn/pages/get-started/how-integrate-your-program/anchor.mdx
@@ -50,7 +50,7 @@ import Endpoints from "/cn/snippets/endpoints.mdx";
   <Card
     title="源代码：Anchor Counter 程序"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -227,7 +227,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## 接入 React 客户端
 
 React 客户端是一个简单的界面，让你可以与 Anchor 程序进行交互。
-它使用 Anchor 绑定与程序通信，并通过 MagicBlock SDK 与 Ephemeral Rollup 会话交互。源代码与程序放在一起，位于 [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app)。
+它使用 Anchor 绑定与程序通信，并通过 MagicBlock SDK 与 Ephemeral Rollup 会话交互。源代码与程序放在一起，位于 [`counter/anchor/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app)。
 
 {" "}
 
@@ -268,7 +268,7 @@ React 客户端是一个简单的界面，让你可以与 Anchor 程序进行交
   <Card
     title="源代码：Anchor Counter 程序"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/cn/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/cn/pages/get-started/how-integrate-your-program/rust.mdx
@@ -55,7 +55,7 @@ import Endpoints from "/cn/snippets/endpoints.mdx";
   <Card
     title="源代码：TypeScript 测试脚本"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -358,7 +358,7 @@ let system_program = next_account_info(account_info_iter)?;
 ## 测试程序
 
 构建出可调用你程序中委托与解除委托相关 instruction 的有效交易。
-该项目的完整测试代码可在 [TypeScript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) 中查看。
+该项目的完整测试代码可在 [TypeScript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests) 中查看。
 
 ### 测试 `delegation` 交易
 
@@ -629,7 +629,7 @@ commitment: "confirmed",
   <Card
     title="源代码：TypeScript 测试脚本"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/cn/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/cn/pages/get-started/how-integrate-your-program/rust.mdx
@@ -49,13 +49,13 @@ import Endpoints from "/cn/snippets/endpoints.mdx";
   <Card
     title="源代码：原生 Rust Counter 程序"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="源代码：TypeScript 测试脚本"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -358,7 +358,7 @@ let system_program = next_account_info(account_info_iter)?;
 ## 测试程序
 
 构建出可调用你程序中委托与解除委托相关 instruction 的有效交易。
-该项目的完整测试代码可在 [TypeScript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests) 中查看。
+该项目的完整测试代码可在 [TypeScript 测试脚本](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) 中查看。
 
 ### 测试 `delegation` 交易
 
@@ -623,13 +623,13 @@ commitment: "confirmed",
   <Card
     title="源代码：原生 Rust Counter 程序"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="源代码：TypeScript 测试脚本"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/cn/pages/get-started/use-cases/payments.mdx
+++ b/cn/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "开启实时链上支付的新时代"
 <Card
   title="源代码"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
   iconType="duotone"
 >
   进一步了解如何使用 MagicBlock 构建并集成链上支付！

--- a/cn/pages/get-started/use-cases/payments.mdx
+++ b/cn/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "开启实时链上支付的新时代"
 <Card
   title="源代码"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/spl-tokens/anchor"
   iconType="duotone"
 >
   进一步了解如何使用 MagicBlock 构建并集成链上支付！

--- a/cn/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
+++ b/cn/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
@@ -215,9 +215,9 @@ Layer 上，通过 MagicBlock 的 Delegation Program
 
 <Tip>
   参考实现：
-  [`private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter)
+  [`private-counter/anchor`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor)
   （Anchor）和
-  [`pinocchio-private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-private-counter)。
+  [`private-counter/pinocchio`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/pinocchio)。
 </Tip>
 
 ---

--- a/cn/pages/templates/counter.mdx
+++ b/cn/pages/templates/counter.mdx
@@ -6,7 +6,7 @@ title: 计数器
   <Card
     title="查看仓库"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     查看源代码与实现

--- a/cn/pages/templates/gachapon.mdx
+++ b/cn/pages/templates/gachapon.mdx
@@ -6,7 +6,7 @@ title: Gachapon
   <Card
     title="查看仓库"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon-example"
     iconType="duotone"
   >
     查看源代码与实现

--- a/cn/pages/templates/onchain-dice.mdx
+++ b/cn/pages/templates/onchain-dice.mdx
@@ -6,7 +6,7 @@ title: 链上骰子
   <Card
     title="查看仓库"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     查看源代码与实现

--- a/cn/pages/templates/rock-paper-scissors.mdx
+++ b/cn/pages/templates/rock-paper-scissors.mdx
@@ -15,7 +15,7 @@ title: 石头剪刀布
   <Card
     title="查看仓库"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor/anchor"
     iconType="duotone"
   >
     查看源代码与实现

--- a/cn/pages/tools/crank/introduction.mdx
+++ b/cn/pages/tools/crank/introduction.mdx
@@ -35,7 +35,7 @@ Cranks（计划任务）能够让链上指令按照预定时间**自动执行**�
   <Card
     title="代码示例"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter/anchor"
     iconType="duotone"
   >
     查看我们的 GitHub 仓库

--- a/cn/snippets/oncurve-delegation.mdx
+++ b/cn/snippets/oncurve-delegation.mdx
@@ -9,7 +9,7 @@ import OncurveUndelegationKitCode from "/cn/snippets/oncurve-undelegation-kit.md
   <Card
     title="GitHub"
     icon="wallet"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation/client"
     iconType="duotone"
   >
     曲线内账户委托

--- a/cn/snippets/quick-access-er-rust.mdx
+++ b/cn/snippets/quick-access-er-rust.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Native Rust 实现
@@ -14,7 +14,7 @@
   <Card
     title="GitHub"
     icon="face-lying"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio"
     iconType="duotone"
   >
     Pinocchio 实现

--- a/cn/snippets/quick-access-er.mdx
+++ b/cn/snippets/quick-access-er.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Anchor 实现

--- a/cn/snippets/quick-access-per.mdx
+++ b/cn/snippets/quick-access-per.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor"
     iconType="duotone"
   >
     Private Counter 的 Anchor 实现

--- a/cn/snippets/quick-access-vrf.mdx
+++ b/cn/snippets/quick-access-vrf.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     掷骰子示例仓库

--- a/jp/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
+++ b/jp/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
@@ -236,7 +236,7 @@ import QuickAccessERFooter from "/jp/snippets/quick-access-er-footer.mdx";
         <Card
           title="Magic Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
           iconType="duotone"
         >
           GitHub 上の参考実装を見る

--- a/jp/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/jp/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ import DelegationInfo from "/jp/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Rust Counter のテスト
@@ -36,7 +36,7 @@ import DelegationInfo from "/jp/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio/tests"
     iconType="duotone"
   >
     Pinocchio Counter のテスト
@@ -56,7 +56,7 @@ import DelegationInfo from "/jp/snippets/delegation-info.mdx";
 ## ステップバイステップガイド
 
 delegation と undelegation 用 instruction を呼び出す有効なトランザクションを組み立てます。
-このプロジェクトの完全なテストは [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests) にあります。
+このプロジェクトの完全なテストは [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) にあります。
 
 <Steps>
   <Step

--- a/jp/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/jp/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ import DelegationInfo from "/jp/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Rust Counter のテスト
@@ -56,7 +56,7 @@ import DelegationInfo from "/jp/snippets/delegation-info.mdx";
 ## ステップバイステップガイド
 
 delegation と undelegation 用 instruction を呼び出す有効なトランザクションを組み立てます。
-このプロジェクトの完全なテストは [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) にあります。
+このプロジェクトの完全なテストは [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests) にあります。
 
 <Steps>
   <Step

--- a/jp/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
+++ b/jp/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
@@ -287,7 +287,7 @@ await erProgram.methods
   <Card
     title="Ephemeral Accounts Demo"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/programs/ephemeral-account-chats"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/anchor/programs/ephemeral-account-chats"
     iconType="duotone"
   >
     Full example program on GitHub

--- a/jp/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
+++ b/jp/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
@@ -52,7 +52,7 @@ import MagicRouterSDK from "/jp/snippets/magic-router-sdk.mdx";
   <Card
     title="Anchor"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Anchor プログラムと統合する
@@ -60,7 +60,7 @@ import MagicRouterSDK from "/jp/snippets/magic-router-sdk.mdx";
   <Card
     title="Native Rust"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Native Rust プログラムと統合する

--- a/jp/pages/ephemeral-rollups-ers/magic-actions/client.mdx
+++ b/jp/pages/ephemeral-rollups-ers/magic-actions/client.mdx
@@ -14,7 +14,7 @@ import KitCode from "/jp/snippets/magic-router-code/kit.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     GitHub でリファレンス実装を見る

--- a/jp/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
+++ b/jp/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
@@ -13,7 +13,7 @@ import MagicActionExample from "/jp/snippets/magic-action-example.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     GitHub でリファレンス実装を見る

--- a/jp/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
+++ b/jp/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
@@ -13,7 +13,7 @@ import DemoCards from "/jp/snippets/demo-cards.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     GitHub でリファレンス実装を見る

--- a/jp/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
+++ b/jp/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
@@ -55,7 +55,7 @@ description: Magic Actions の一般的な問題を診断する
 <Card
   title="Magic Actions Example"
   icon="code"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
   iconType="duotone"
 >
   GitHub でリファレンス実装を見る

--- a/jp/pages/get-started/how-integrate-your-program/anchor.mdx
+++ b/jp/pages/get-started/how-integrate-your-program/anchor.mdx
@@ -50,7 +50,7 @@ import Endpoints from "/jp/snippets/endpoints.mdx";
   <Card
     title="ソースコード：Anchor Counter プログラム"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -227,7 +227,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## React クライアントの接続
 
 React クライアントは Anchor プログラムと対話するためのシンプルなインターフェースです。
-Anchor バインディングを使ってプログラムと通信し、MagicBlock SDK で Ephemeral Rollup セッションとやり取りします。ソースはプログラムと同じ場所、[`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app) にあります。
+Anchor バインディングを使ってプログラムと通信し、MagicBlock SDK で Ephemeral Rollup セッションとやり取りします。ソースはプログラムと同じ場所、[`counter/anchor/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app) にあります。
 
 {" "}
 
@@ -268,7 +268,7 @@ Ephemeral Rollup セッションと対話するには、適切なエンドポイ
   <Card
     title="ソースコード：Anchor Counter プログラム"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/jp/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/jp/pages/get-started/how-integrate-your-program/rust.mdx
@@ -55,7 +55,7 @@ import Endpoints from "/jp/snippets/endpoints.mdx";
   <Card
     title="ソースコード：TypeScript テストスクリプト"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -356,7 +356,7 @@ pub fn process_undelegate(
 ## プログラムのテスト
 
 あなたのプログラムにある委任・委任解除関連の instruction を呼び出す有効なトランザクションを構築します。
-プロジェクトの完全なテストコードは [TypeScript テストスクリプト](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) で確認できます。
+プロジェクトの完全なテストコードは [TypeScript テストスクリプト](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests) で確認できます。
 
 ### `delegation` トランザクションのテスト
 
@@ -627,7 +627,7 @@ Ephemeral Rollup セッションと対話するには、適切なエンドポイ
   <Card
     title="ソースコード：TypeScript テストスクリプト"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/jp/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/jp/pages/get-started/how-integrate-your-program/rust.mdx
@@ -49,13 +49,13 @@ import Endpoints from "/jp/snippets/endpoints.mdx";
   <Card
     title="ソースコード：ネイティブ Rust Counter プログラム"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="ソースコード：TypeScript テストスクリプト"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -356,7 +356,7 @@ pub fn process_undelegate(
 ## プログラムのテスト
 
 あなたのプログラムにある委任・委任解除関連の instruction を呼び出す有効なトランザクションを構築します。
-プロジェクトの完全なテストコードは [TypeScript テストスクリプト](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests) で確認できます。
+プロジェクトの完全なテストコードは [TypeScript テストスクリプト](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) で確認できます。
 
 ### `delegation` トランザクションのテスト
 
@@ -621,13 +621,13 @@ Ephemeral Rollup セッションと対話するには、適切なエンドポイ
   <Card
     title="ソースコード：ネイティブ Rust Counter プログラム"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="ソースコード：TypeScript テストスクリプト"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/jp/pages/get-started/use-cases/payments.mdx
+++ b/jp/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "リアルタイムなオンチェーン決済の新時代を切り
 <Card
   title="ソースコード"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
   iconType="duotone"
 >
   MagicBlock を使ったオンチェーン決済の構築と統合について詳しく見る

--- a/jp/pages/get-started/use-cases/payments.mdx
+++ b/jp/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "リアルタイムなオンチェーン決済の新時代を切り
 <Card
   title="ソースコード"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/spl-tokens/anchor"
   iconType="duotone"
 >
   MagicBlock を使ったオンチェーン決済の構築と統合について詳しく見る

--- a/jp/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
+++ b/jp/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
@@ -220,9 +220,9 @@ Private Ephemeral Rollups は、[コンプライアンス](/jp/pages/private-eph
 
 <Tip>
   参考実装:
-  [`private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter)
+  [`private-counter/anchor`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor)
   （Anchor）と
-  [`pinocchio-private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-private-counter)。
+  [`private-counter/pinocchio`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/pinocchio)。
 </Tip>
 
 ---

--- a/jp/pages/templates/counter.mdx
+++ b/jp/pages/templates/counter.mdx
@@ -6,7 +6,7 @@ title: カウンター
   <Card
     title="リポジトリを見る"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     ソースコードと実装を見る

--- a/jp/pages/templates/gachapon.mdx
+++ b/jp/pages/templates/gachapon.mdx
@@ -6,7 +6,7 @@ title: Gachapon
   <Card
     title="リポジトリを見る"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon-example"
     iconType="duotone"
   >
     ソースコードと実装を見る

--- a/jp/pages/templates/onchain-dice.mdx
+++ b/jp/pages/templates/onchain-dice.mdx
@@ -6,7 +6,7 @@ title: オンチェーンダイス
   <Card
     title="リポジトリを見る"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     ソースコードと実装を見る

--- a/jp/pages/templates/rock-paper-scissors.mdx
+++ b/jp/pages/templates/rock-paper-scissors.mdx
@@ -15,7 +15,7 @@ title: じゃんけん
   <Card
     title="リポジトリを見る"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor/anchor"
     iconType="duotone"
   >
     ソースコードと実装を見る

--- a/jp/pages/tools/crank/introduction.mdx
+++ b/jp/pages/tools/crank/introduction.mdx
@@ -35,7 +35,7 @@ MagicBlock の Ephemeral Rollups を使えば、あらかじめ決めた間隔�
   <Card
     title="コード例"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter/anchor"
     iconType="duotone"
   >
     GitHub リポジトリを見る

--- a/jp/snippets/oncurve-delegation.mdx
+++ b/jp/snippets/oncurve-delegation.mdx
@@ -9,7 +9,7 @@ import OncurveUndelegationKitCode from "/jp/snippets/oncurve-undelegation-kit.md
   <Card
     title="GitHub"
     icon="wallet"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation/client"
     iconType="duotone"
   >
     オンカーブ委任

--- a/jp/snippets/quick-access-er-rust.mdx
+++ b/jp/snippets/quick-access-er-rust.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Native Rust 実装
@@ -14,7 +14,7 @@
   <Card
     title="GitHub"
     icon="face-lying"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio"
     iconType="duotone"
   >
     Pinocchio 実装

--- a/jp/snippets/quick-access-er.mdx
+++ b/jp/snippets/quick-access-er.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Anchor 実装

--- a/jp/snippets/quick-access-per.mdx
+++ b/jp/snippets/quick-access-per.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor"
     iconType="duotone"
   >
     Private Counter の Anchor 実装

--- a/jp/snippets/quick-access-vrf.mdx
+++ b/jp/snippets/quick-access-vrf.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     サイコロサンプルのリポジトリ

--- a/ko/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
+++ b/ko/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
@@ -236,7 +236,7 @@ import QuickAccessERFooter from "/ko/snippets/quick-access-er-footer.mdx";
         <Card
           title="Magic Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
           iconType="duotone"
         >
           GitHub에서 레퍼런스 구현 보기

--- a/ko/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/ko/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ import DelegationInfo from "/ko/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Rust Counter 테스트
@@ -56,7 +56,7 @@ import DelegationInfo from "/ko/snippets/delegation-info.mdx";
 ## 단계별 가이드
 
 프로그램의 delegation 및 undelegation instruction을 호출하는 유효한 트랜잭션을 구성하세요。
-이 프로젝트의 전체 테스트는 [Typescript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) 에서 확인할 수 있습니다。
+이 프로젝트의 전체 테스트는 [Typescript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests) 에서 확인할 수 있습니다。
 
 <Steps>
   <Step

--- a/ko/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/ko/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ import DelegationInfo from "/ko/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Rust Counter 테스트
@@ -36,7 +36,7 @@ import DelegationInfo from "/ko/snippets/delegation-info.mdx";
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio/tests"
     iconType="duotone"
   >
     Pinocchio Counter 테스트
@@ -56,7 +56,7 @@ import DelegationInfo from "/ko/snippets/delegation-info.mdx";
 ## 단계별 가이드
 
 프로그램의 delegation 및 undelegation instruction을 호출하는 유효한 트랜잭션을 구성하세요。
-이 프로젝트의 전체 테스트는 [Typescript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests) 에서 확인할 수 있습니다。
+이 프로젝트의 전체 테스트는 [Typescript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests) 에서 확인할 수 있습니다。
 
 <Steps>
   <Step

--- a/ko/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
+++ b/ko/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
@@ -287,7 +287,7 @@ await erProgram.methods
   <Card
     title="Ephemeral Accounts Demo"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/programs/ephemeral-account-chats"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/anchor/programs/ephemeral-account-chats"
     iconType="duotone"
   >
     Full example program on GitHub

--- a/ko/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
+++ b/ko/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
@@ -52,7 +52,7 @@ import MagicRouterSDK from "/ko/snippets/magic-router-sdk.mdx";
   <Card
     title="Anchor"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Anchor 프로그램과 통합하기
@@ -60,7 +60,7 @@ import MagicRouterSDK from "/ko/snippets/magic-router-sdk.mdx";
   <Card
     title="Native Rust"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Native Rust 프로그램과 통합하기

--- a/ko/pages/ephemeral-rollups-ers/magic-actions/client.mdx
+++ b/ko/pages/ephemeral-rollups-ers/magic-actions/client.mdx
@@ -14,7 +14,7 @@ import KitCode from "/ko/snippets/magic-router-code/kit.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     GitHub에서 참조 구현 살펴보기

--- a/ko/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
+++ b/ko/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
@@ -13,7 +13,7 @@ import MagicActionExample from "/ko/snippets/magic-action-example.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     GitHub에서 참조 구현 살펴보기

--- a/ko/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
+++ b/ko/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
@@ -13,7 +13,7 @@ import DemoCards from "/ko/snippets/demo-cards.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     GitHub에서 참조 구현 살펴보기

--- a/ko/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
+++ b/ko/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
@@ -55,7 +55,7 @@ description: Magic Actions에서 자주 발생하는 문제를 진단합니다
 <Card
   title="Magic Actions Example"
   icon="code"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
   iconType="duotone"
 >
   GitHub에서 참조 구현 살펴보기

--- a/ko/pages/get-started/how-integrate-your-program/anchor.mdx
+++ b/ko/pages/get-started/how-integrate-your-program/anchor.mdx
@@ -50,7 +50,7 @@ import Endpoints from "/ko/snippets/endpoints.mdx";
   <Card
     title="소스 코드: Anchor Counter 프로그램"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -227,7 +227,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## React 클라이언트 연결
 
 React 클라이언트는 Anchor 프로그램과 상호작용할 수 있게 해주는 간단한 인터페이스입니다.
-Anchor 바인딩을 사용해 프로그램과 통신하고, MagicBlock SDK로 Ephemeral Rollup 세션과 상호작용합니다. 소스는 프로그램과 같은 위치인 [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app)에 있습니다.
+Anchor 바인딩을 사용해 프로그램과 통신하고, MagicBlock SDK로 Ephemeral Rollup 세션과 상호작용합니다. 소스는 프로그램과 같은 위치인 [`counter/anchor/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app)에 있습니다.
 
 {" "}
 
@@ -268,7 +268,7 @@ Ephemeral Rollup 세션과 상호작용하려면 적절한 엔드포인트를 �
   <Card
     title="소스 코드: Anchor Counter 프로그램"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/ko/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/ko/pages/get-started/how-integrate-your-program/rust.mdx
@@ -55,7 +55,7 @@ import Endpoints from "/ko/snippets/endpoints.mdx";
   <Card
     title="소스 코드: TypeScript 테스트 스크립트"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -356,7 +356,7 @@ pub fn process_undelegate(
 ## 프로그램 테스트하기
 
 여러분의 프로그램에 있는 위임 및 위임 해제 관련 인스트럭션을 호출하는 유효한 트랜잭션을 구성합니다.
-프로젝트의 전체 테스트 코드는 [TypeScript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests)에서 확인할 수 있습니다.
+프로젝트의 전체 테스트 코드는 [TypeScript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests)에서 확인할 수 있습니다.
 
 ### `delegation` 트랜잭션 테스트
 
@@ -627,7 +627,7 @@ Ephemeral Rollup 세션과 상호작용하려면 적절한 엔드포인트를 �
   <Card
     title="소스 코드: TypeScript 테스트 스크립트"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/ko/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/ko/pages/get-started/how-integrate-your-program/rust.mdx
@@ -49,13 +49,13 @@ import Endpoints from "/ko/snippets/endpoints.mdx";
   <Card
     title="소스 코드: 네이티브 Rust 카운터 프로그램"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="소스 코드: TypeScript 테스트 스크립트"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -356,7 +356,7 @@ pub fn process_undelegate(
 ## 프로그램 테스트하기
 
 여러분의 프로그램에 있는 위임 및 위임 해제 관련 인스트럭션을 호출하는 유효한 트랜잭션을 구성합니다.
-프로젝트의 전체 테스트 코드는 [TypeScript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests)에서 확인할 수 있습니다.
+프로젝트의 전체 테스트 코드는 [TypeScript 테스트 스크립트](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests)에서 확인할 수 있습니다.
 
 ### `delegation` 트랜잭션 테스트
 
@@ -621,13 +621,13 @@ Ephemeral Rollup 세션과 상호작용하려면 적절한 엔드포인트를 �
   <Card
     title="소스 코드: 네이티브 Rust 카운터 프로그램"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="소스 코드: TypeScript 테스트 스크립트"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/ko/pages/get-started/use-cases/payments.mdx
+++ b/ko/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "실시간 온체인 결제의 새로운 시대를 열어보세요"
 <Card
   title="소스 코드"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/spl-tokens/anchor"
   iconType="duotone"
 >
   MagicBlock로 온체인 결제를 구축하고 통합하는 방법을 자세히 알아보세요!

--- a/ko/pages/get-started/use-cases/payments.mdx
+++ b/ko/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "실시간 온체인 결제의 새로운 시대를 열어보세요"
 <Card
   title="소스 코드"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
   iconType="duotone"
 >
   MagicBlock로 온체인 결제를 구축하고 통합하는 방법을 자세히 알아보세요!

--- a/ko/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
+++ b/ko/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
@@ -220,9 +220,9 @@ ephemeral permission 렌트를 지불합니다 — 따라서 `initialize` 시점
 
 <Tip>
   참고 구현:
-  [`private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter)
+  [`private-counter/anchor`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor)
   (Anchor)와
-  [`pinocchio-private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-private-counter)。
+  [`private-counter/pinocchio`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/pinocchio)。
 </Tip>
 
 ---

--- a/ko/pages/templates/counter.mdx
+++ b/ko/pages/templates/counter.mdx
@@ -6,7 +6,7 @@ title: 카운터
   <Card
     title="저장소 보기"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     소스 코드와 구현 살펴보기

--- a/ko/pages/templates/gachapon.mdx
+++ b/ko/pages/templates/gachapon.mdx
@@ -6,7 +6,7 @@ title: Gachapon
   <Card
     title="저장소 보기"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon-example"
     iconType="duotone"
   >
     소스 코드와 구현 살펴보기

--- a/ko/pages/templates/onchain-dice.mdx
+++ b/ko/pages/templates/onchain-dice.mdx
@@ -6,7 +6,7 @@ title: 온체인 주사위
   <Card
     title="저장소 보기"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     소스 코드와 구현 살펴보기

--- a/ko/pages/templates/rock-paper-scissors.mdx
+++ b/ko/pages/templates/rock-paper-scissors.mdx
@@ -15,7 +15,7 @@ title: 가위바위보
   <Card
     title="저장소 보기"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor/anchor"
     iconType="duotone"
   >
     소스 코드와 구현 살펴보기

--- a/ko/pages/tools/crank/introduction.mdx
+++ b/ko/pages/tools/crank/introduction.mdx
@@ -35,7 +35,7 @@ MagicBlock의 Ephemeral Rollups를 사용하면 미리 정한 간격에 따라 �
   <Card
     title="코드 예시"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter/anchor"
     iconType="duotone"
   >
     GitHub 저장소 보기

--- a/ko/snippets/oncurve-delegation.mdx
+++ b/ko/snippets/oncurve-delegation.mdx
@@ -9,7 +9,7 @@ import OncurveUndelegationKitCode from "/ko/snippets/oncurve-undelegation-kit.md
   <Card
     title="GitHub"
     icon="wallet"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation/client"
     iconType="duotone"
   >
     온커브 위임

--- a/ko/snippets/quick-access-er-rust.mdx
+++ b/ko/snippets/quick-access-er-rust.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Native Rust 구현
@@ -14,7 +14,7 @@
   <Card
     title="GitHub"
     icon="face-lying"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio"
     iconType="duotone"
   >
     Pinocchio 구현

--- a/ko/snippets/quick-access-er.mdx
+++ b/ko/snippets/quick-access-er.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Anchor 구현

--- a/ko/snippets/quick-access-per.mdx
+++ b/ko/snippets/quick-access-per.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor"
     iconType="duotone"
   >
     Private Counter의 Anchor 구현

--- a/ko/snippets/quick-access-vrf.mdx
+++ b/ko/snippets/quick-access-vrf.mdx
@@ -6,7 +6,7 @@
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     주사위 예제 저장소

--- a/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
+++ b/pages/ephemeral-rollups-ers/how-to-guide/quickstart.mdx
@@ -235,7 +235,7 @@ Build your program and upgrade it with delegation hooks with MagicBlock's Delega
         <Card
           title="Magic Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
           iconType="duotone"
         >
           Explore reference implementation on GitHub
@@ -275,7 +275,7 @@ Build your program and upgrade it with delegation hooks with MagicBlock's Delega
         <Card
           title="Delegation Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/delegation-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/delegation-actions/anchor"
           iconType="duotone"
         >
           Explore reference implementation on GitHub

--- a/pages/ephemeral-rollups-ers/how-to-guide/rust-program.mdx
+++ b/pages/ephemeral-rollups-ers/how-to-guide/rust-program.mdx
@@ -266,7 +266,7 @@ Build your program and upgrade it with delegation hooks with MagicBlock’s Dele
         <Card
           title="Delegation Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/delegation-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/delegation-actions/anchor"
           iconType="duotone"
         >
           Explore reference implementation on GitHub

--- a/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ If you prefer to dive straight into the code:
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Tests for Rust Counter
@@ -36,7 +36,7 @@ If you prefer to dive straight into the code:
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio/tests"
     iconType="duotone"
   >
     Tests for Pinocchio Counter
@@ -56,7 +56,7 @@ If you prefer to dive straight into the code:
 ## Step-By-Step Guide
 
 Build valid transactions that calls your program instructions for delegation and undelegation.
-The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests).
+The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests).
 
 <Steps>
   <Step

--- a/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
+++ b/pages/ephemeral-rollups-ers/how-to-guide/rust-tests.mdx
@@ -28,7 +28,7 @@ If you prefer to dive straight into the code:
   <Card
     title="GitHub"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   >
     Tests for Rust Counter
@@ -56,7 +56,7 @@ If you prefer to dive straight into the code:
 ## Step-By-Step Guide
 
 Build valid transactions that calls your program instructions for delegation and undelegation.
-The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests).
+The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests).
 
 <Steps>
   <Step

--- a/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
+++ b/pages/ephemeral-rollups-ers/introduction/ephemeral-accounts.mdx
@@ -287,7 +287,7 @@ await erProgram.methods
   <Card
     title="Ephemeral Accounts Demo"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/programs/ephemeral-account-chats"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/ephemeral-account-chats/anchor/programs/ephemeral-account-chats"
     iconType="duotone"
   >
     Full example program on GitHub

--- a/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
+++ b/pages/ephemeral-rollups-ers/introduction/magic-router.mdx
@@ -52,7 +52,7 @@ This eliminates the need for manual routing logic from the developer, providing 
   <Card
     title="Anchor"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Integrate with an Anchor program
@@ -60,7 +60,7 @@ This eliminates the need for manual routing logic from the developer, providing 
   <Card
     title="Native Rust"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Integrate with a Native Rust program

--- a/pages/ephemeral-rollups-ers/magic-actions/client.mdx
+++ b/pages/ephemeral-rollups-ers/magic-actions/client.mdx
@@ -14,7 +14,7 @@ import KitCode from "/snippets/magic-router-code/kit.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     Explore reference implementation on GitHub

--- a/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
+++ b/pages/ephemeral-rollups-ers/magic-actions/implementation.mdx
@@ -13,7 +13,7 @@ import MagicActionExample from "/snippets/magic-action-example.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     Explore reference implementation on GitHub

--- a/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
+++ b/pages/ephemeral-rollups-ers/magic-actions/overview.mdx
@@ -13,7 +13,7 @@ import DemoCards from "/snippets/demo-cards.mdx";
   <Card
     title="Magic Actions Example"
     icon="code"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
     iconType="duotone"
   >
     Explore reference implementation on GitHub

--- a/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
+++ b/pages/ephemeral-rollups-ers/magic-actions/troubleshooting.mdx
@@ -55,7 +55,7 @@ description: Diagnose common issues with Magic Actions
 <Card
   title="Magic Actions Example"
   icon="code"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
   iconType="duotone"
 >
   Explore reference implementation on GitHub

--- a/pages/get-started/how-integrate-your-program/anchor.mdx
+++ b/pages/get-started/how-integrate-your-program/anchor.mdx
@@ -50,7 +50,7 @@ If you prefer to dive straight into the code:
   <Card
     title="Source Code: Anchor Counter Program"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -228,7 +228,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## Connecting the React Client
 
 The React client is a simple interface that allows you to interact with the Anchor program.
-It uses the Anchor bindings to interact with the program and the MagicBlock SDK to interact with the Ephemeral Rollup session. Source lives alongside the program at [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app).
+It uses the Anchor bindings to interact with the program and the MagicBlock SDK to interact with the Ephemeral Rollup session. Source lives alongside the program at [`counter/anchor/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app).
 
 {" "}
 
@@ -270,7 +270,7 @@ Make sure to update your client configuration to use the correct endpoint based 
   <Card
     title="Source Code: Anchor Counter Program"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/pages/get-started/how-integrate-your-program/rust.mdx
@@ -55,7 +55,7 @@ If you prefer to dive straight into the code:
   <Card
     title="Source Code: Typescript Test Script"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -360,7 +360,7 @@ let system_program = next_account_info(account_info_iter)?;
 ## Testing the program
 
 Build valid transactions that calls your program instructions for delegation and undelegation.
-The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests).
+The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests).
 
 ### Test `delegation` transaction
 
@@ -631,7 +631,7 @@ Make sure to update your client configuration to use the correct endpoint based 
   <Card
     title="Source Code: Typescript Test Script"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/pages/get-started/how-integrate-your-program/rust.mdx
+++ b/pages/get-started/how-integrate-your-program/rust.mdx
@@ -49,13 +49,13 @@ If you prefer to dive straight into the code:
   <Card
     title="Source Code: Native Rust Counter Program"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="Source Code: Typescript Test Script"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>
@@ -360,7 +360,7 @@ let system_program = next_account_info(account_info_iter)?;
 ## Testing the program
 
 Build valid transactions that calls your program instructions for delegation and undelegation.
-The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests).
+The complete test for this project can be found in the [Typescript Test Script](https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests).
 
 ### Test `delegation` transaction
 
@@ -625,13 +625,13 @@ Make sure to update your client configuration to use the correct endpoint based 
   <Card
     title="Source Code: Native Rust Counter Program"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   ></Card>
   <Card
     title="Source Code: Typescript Test Script"
     icon="js"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/rust-counter/tests"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/blob/main/counter/native-rust/tests"
     iconType="duotone"
   ></Card>
 </CardGroup>

--- a/pages/get-started/use-cases/payments.mdx
+++ b/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "Unlock the next era of real-time on-chain payments"
 <Card
   title="Source Code"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
   iconType="duotone"
 >
   Learn more about building and integrating on-chain payments with MagicBlock!

--- a/pages/get-started/use-cases/payments.mdx
+++ b/pages/get-started/use-cases/payments.mdx
@@ -26,7 +26,7 @@ description: "Unlock the next era of real-time on-chain payments"
 <Card
   title="Source Code"
   icon="github"
-  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/dummy-token-transfer/anchor"
+  href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/spl-tokens/anchor"
   iconType="duotone"
 >
   Learn more about building and integrating on-chain payments with MagicBlock!

--- a/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
+++ b/pages/private-ephemeral-rollups-pers/how-to-guide/access-control.mdx
@@ -221,10 +221,10 @@ for the end-to-end flow.
 
 <Tip>
   Reference implementations:
-  [`private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter)
+  [`private-counter/anchor`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor)
   (Anchor)
   and
-  [`pinocchio-private-counter`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-private-counter).
+  [`private-counter/pinocchio`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/pinocchio).
 </Tip>
 
 ---

--- a/pages/private-ephemeral-rollups-pers/how-to-guide/quickstart.mdx
+++ b/pages/private-ephemeral-rollups-pers/how-to-guide/quickstart.mdx
@@ -172,7 +172,7 @@ These ER building blocks work the same way inside a Private Ephemeral Rollup.
         <Card
           title="Magic Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/magic-actions/anchor"
           iconType="duotone"
         >
           Explore reference implementation on GitHub
@@ -212,7 +212,7 @@ These ER building blocks work the same way inside a Private Ephemeral Rollup.
         <Card
           title="Delegation Actions Example"
           icon="code"
-          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/delegation-actions"
+          href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/delegation-actions/anchor"
           iconType="duotone"
         >
           Explore reference implementation on GitHub

--- a/pages/templates/counter.mdx
+++ b/pages/templates/counter.mdx
@@ -6,7 +6,7 @@ title: Counter
   <Card
     title="View Repository"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Explore the source code and implementation

--- a/pages/templates/gachapon.mdx
+++ b/pages/templates/gachapon.mdx
@@ -6,7 +6,7 @@ title: Gachapon
   <Card
     title="View Repository"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/gachapon-example"
     iconType="duotone"
   >
     Explore the source code and implementation

--- a/pages/templates/onchain-dice.mdx
+++ b/pages/templates/onchain-dice.mdx
@@ -6,7 +6,7 @@ title: Onchain Dice
   <Card
     title="View Repository"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     Explore the source code and implementation

--- a/pages/templates/rock-paper-scissors.mdx
+++ b/pages/templates/rock-paper-scissors.mdx
@@ -15,7 +15,7 @@ title: Rock Paper Scissors
   <Card
     title="View Repository"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rock-paper-scissor/anchor"
     iconType="duotone"
   >
     Explore the source code and implementation

--- a/pages/tools/crank/introduction.mdx
+++ b/pages/tools/crank/introduction.mdx
@@ -35,7 +35,7 @@ With MagicBlock's Ephemeral Rollups, you can schedule tasks that execute automat
   <Card
     title="Code Example"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/crank-counter/anchor"
     iconType="duotone"
   >
     Check out our GitHub repository

--- a/snippets/oncurve-delegation.mdx
+++ b/snippets/oncurve-delegation.mdx
@@ -9,7 +9,7 @@ import OncurveUndelegationKitCode from "/snippets/oncurve-undelegation-kit.mdx";
   <Card
     title="GitHub"
     icon="wallet"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/oncurve-delegation/client"
     iconType="duotone"
   >
     On-Curve Delegation

--- a/snippets/quick-access-er-rust.mdx
+++ b/snippets/quick-access-er-rust.mdx
@@ -6,7 +6,7 @@ Check out basic counter example in other implementations:
   <Card
     title="GitHub"
     icon="rust"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/rust-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/native-rust"
     iconType="duotone"
   >
     Native Rust Implementation
@@ -14,7 +14,7 @@ Check out basic counter example in other implementations:
   <Card
     title="GitHub"
     icon="face-lying"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/pinocchio-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/pinocchio"
     iconType="duotone"
   >
     Pinocchio Implementation

--- a/snippets/quick-access-er.mdx
+++ b/snippets/quick-access-er.mdx
@@ -6,7 +6,7 @@ Check out basic counter example:
   <Card
     title="GitHub"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   >
     Anchor Implementation

--- a/snippets/quick-access-per.mdx
+++ b/snippets/quick-access-per.mdx
@@ -6,7 +6,7 @@ Check out example:
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/private-counter/anchor"
     iconType="duotone"
   >
     Private Counter Anchor Implementation

--- a/snippets/quick-access-vrf.mdx
+++ b/snippets/quick-access-vrf.mdx
@@ -6,7 +6,7 @@ Check out basic VRF examples:
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/roll-dice/anchor"
     iconType="duotone"
   >
     Repo for roll dice example


### PR DESCRIPTION
## Merge order

Depends on https://github.com/magicblock-labs/magicblock-engine-examples/pull/108.

Do not merge this PR until magicblock-labs/magicblock-engine-examples#108 is merged, otherwise these links will point to paths that do not exist on `main`.

## Summary

Updates docs links to `magicblock-engine-examples` after the example repo refactor that groups implementations by use case and framework.

## Changes

- Update example links across English, Chinese, Japanese, and Korean docs/snippets.
- Point framework-specific examples to their new paths, such as:
  - `anchor-counter` -> `counter/anchor`
  - `rust-counter` -> `counter/native-rust`
  - `pinocchio-counter` -> `counter/pinocchio`
  - `magic-actions` -> `magic-actions/anchor`
  - `roll-dice` -> `roll-dice/anchor`
- Update visible path labels where they referenced moved folders.

## Validation

- `git diff --check`
- Custom stale moved example URL scan
- `npx -y mintlify validate`

## Breaking changes

None for the docs site after magicblock-labs/magicblock-engine-examples#108 is merged. Before that dependency merges, the updated external links target paths that are not yet on the examples repo `main` branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated many example and quick-access links across English, Chinese, Japanese, Korean, and general docs to point to more specific, current example locations.
  * Improved references for Anchor, Native Rust, Pinocchio, Magic Actions, private counter examples, and other templates so users reach the intended repository pages more easily.
  * Several payments, crank, and delegation-related links were also refreshed to match the latest example paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->