### PR TITLE
fix: update stale magicblock-engine-examples links

### DIFF
--- a/cn/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
+++ b/cn/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
@@ -50,7 +50,7 @@ import Endpoints from "/cn/snippets/endpoints.mdx";
   <Card
     title="源代码：Anchor Counter 程序"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -227,7 +227,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## 接入 React 客户端
 
 React 客户端是一个简单的界面，让你可以与 Anchor 程序进行交互。
-它使用 Anchor 绑定与程序通信，并通过 MagicBlock SDK 与 Ephemeral Rollup 会话交互。源代码与程序放在一起，位于 [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app)。
+它使用 Anchor 绑定与程序通信，并通过 MagicBlock SDK 与 Ephemeral Rollup 会话交互。源代码与程序放在一起，位于 [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app)。
 
 {" "}
 
@@ -268,7 +268,7 @@ React 客户端是一个简单的界面，让你可以与 Anchor 程序进行交
   <Card
     title="源代码：Anchor Counter 程序"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/jp/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
+++ b/jp/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
@@ -50,7 +50,7 @@ import Endpoints from "/jp/snippets/endpoints.mdx";
   <Card
     title="ソースコード：Anchor Counter プログラム"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -227,7 +227,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## React クライアントの接続
 
 React クライアントは Anchor プログラムと対話するためのシンプルなインターフェースです。
-Anchor バインディングを使ってプログラムと通信し、MagicBlock SDK で Ephemeral Rollup セッションとやり取りします。ソースはプログラムと同じ場所、[`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app) にあります。
+Anchor バインディングを使ってプログラムと通信し、MagicBlock SDK で Ephemeral Rollup セッションとやり取りします。ソースはプログラムと同じ場所、[`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app) にあります。
 
 {" "}
 
@@ -268,7 +268,7 @@ Ephemeral Rollup セッションと対話するには、適切なエンドポイ
   <Card
     title="ソースコード：Anchor Counter プログラム"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/ko/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
+++ b/ko/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
@@ -50,7 +50,7 @@ import Endpoints from "/ko/snippets/endpoints.mdx";
   <Card
     title="소스 코드: Anchor Counter 프로그램"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -227,7 +227,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## React 클라이언트 연결
 
 React 클라이언트는 Anchor 프로그램과 상호작용할 수 있게 해주는 간단한 인터페이스입니다.
-Anchor 바인딩을 사용해 프로그램과 통신하고, MagicBlock SDK로 Ephemeral Rollup 세션과 상호작용합니다. 소스는 프로그램과 같은 위치인 [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app)에 있습니다.
+Anchor 바인딩을 사용해 프로그램과 통신하고, MagicBlock SDK로 Ephemeral Rollup 세션과 상호작용합니다. 소스는 프로그램과 같은 위치인 [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app)에 있습니다.
 
 {" "}
 
@@ -268,7 +268,7 @@ Ephemeral Rollup 세션과 상호작용하려면 적절한 엔드포인트를 �
   <Card
     title="소스 코드: Anchor Counter 프로그램"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card

--- a/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
+++ b/pages/ephemeral-rollups-ers/how-to-guide/anchor.mdx
@@ -50,7 +50,7 @@ If you prefer to dive straight into the code:
   <Card
     title="Source Code: Anchor Counter Program"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card
@@ -228,7 +228,7 @@ pub fn undelegate(ctx: Context<IncrementAndCommit>) -> Result<()> {
 ## Connecting the React Client
 
 The React client is a simple interface that allows you to interact with the Anchor program.
-It uses the Anchor bindings to interact with the program and the MagicBlock SDK to interact with the Ephemeral Rollup session. Source lives alongside the program at [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter/app).
+It uses the Anchor bindings to interact with the program and the MagicBlock SDK to interact with the Ephemeral Rollup session. Source lives alongside the program at [`anchor-counter/app`](https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor/app).
 
 {" "}
 
@@ -270,7 +270,7 @@ Make sure to update your client configuration to use the correct endpoint based 
   <Card
     title="Source Code: Anchor Counter Program"
     icon="anchor"
-    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/anchor-counter"
+    href="https://github.com/magicblock-labs/magicblock-engine-examples/tree/main/counter/anchor"
     iconType="duotone"
   ></Card>
   <Card


### PR DESCRIPTION
Fixes some broken links to the counter example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guide links and source-path references to match the new repository structure.
  * Clarified where to find the Anchor Counter program and related React client source in the documentation.
  * Applied the same link updates across all localized versions of the guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->